### PR TITLE
feat: add authkit_supported_platforms filter to PicaClientOptions

### DIFF
--- a/pica_langchain/client.py
+++ b/pica_langchain/client.py
@@ -74,6 +74,8 @@ class PicaClient:
         else:
             self._system_prompt = get_default_system_prompt("Loading connections...")
         
+        self._authkit_supported_platforms = options.authkit_supported_platforms
+        
         self.initialize()
     
     def initialize(self) -> None:
@@ -116,9 +118,18 @@ class PicaClient:
             else "No connections available"
         )
         
+        # Filter connection definitions based on authkit_supported_platforms if provided
+        filtered_connection_definitions = self.connection_definitions
+        if self._use_authkit and self._authkit_supported_platforms:
+            filtered_connection_definitions = [
+                def_ for def_ in self.connection_definitions 
+                if def_.platform in self._authkit_supported_platforms
+            ]
+            logger.debug(f"Filtered available platforms from {len(self.connection_definitions)} to {len(filtered_connection_definitions)} based on authkit_supported_platforms")
+        
         available_platforms_info = "\n\t* ".join([
             f"{def_.platform} ({def_.frontend.spec.title})"
-            for def_ in self.connection_definitions
+            for def_ in filtered_connection_definitions
         ])
         
         if self._use_authkit:
@@ -132,6 +143,9 @@ class PicaClient:
                 available_platforms_info
             )
 
+        logger.info(f"authkit supported platform = {self._authkit_supported_platforms}")
+        logger.info(f"connections_info = {connections_info}")
+        logger.info(f"available_platforms_info = {available_platforms_info}")
         self._initialized = True
         logger.info("Pica client initialization complete")
     

--- a/pica_langchain/client.py
+++ b/pica_langchain/client.py
@@ -117,10 +117,11 @@ class PicaClient:
             if filtered_connections 
             else "No connections available"
         )
-        
+                
         # Filter connection definitions based on authkit_supported_platforms if provided
         filtered_connection_definitions = self.connection_definitions
         if self._use_authkit and self._authkit_supported_platforms:
+            logger.info(f"Authkit supported platform = {self._authkit_supported_platforms}")
             filtered_connection_definitions = [
                 def_ for def_ in self.connection_definitions 
                 if def_.platform in self._authkit_supported_platforms
@@ -142,10 +143,7 @@ class PicaClient:
                 connections_info, 
                 available_platforms_info
             )
-
-        logger.info(f"authkit supported platform = {self._authkit_supported_platforms}")
-        logger.info(f"connections_info = {connections_info}")
-        logger.info(f"available_platforms_info = {available_platforms_info}")
+        
         self._initialized = True
         logger.info("Pica client initialization complete")
     

--- a/pica_langchain/models.py
+++ b/pica_langchain/models.py
@@ -273,6 +273,10 @@ class PicaClientOptions(BaseModel):
         default=False,
         description="Whether to use the AuthKit integration which enables the promptToConnectPlatform tool"
     )
+    authkit_supported_platforms: List[str] = Field(
+        default_factory=list,
+        description="List of platform identifiers to include in the available platforms list for AuthKit. Use empty list to include all platforms."
+    )    
     
     model_config = ConfigDict(
         populate_by_name=True,

--- a/pica_langchain/prompts/authkit_system.py
+++ b/pica_langchain/prompts/authkit_system.py
@@ -18,6 +18,9 @@ You have access to many tools and APIs through Pica OneTool. Before executing an
 If the user does not have the required connection, call the PromptToConnectPlatformTool tool to add the connection.
 (DO NOT TELL THE USER TO ADD A CONNECTION VIA THE PICA DASHBOARD BECAUSE YOU HAVE THE ABILITY TO ADD A CONNECTION VIA THE PromptToConnectPlatformTool tool)
 If the user is asking to connect or does not have the connection required to execute the action, call the PromptToConnectPlatformTool tool to add the connection.
+If the user asks about "supported connections" list down the information nicely from available_platforms_info provided in the prompt here
+If the user asks about all the connected platforms, list down the information nicely from connections_info provided in the prompt here
+
 
 If a platform has no connection:
 * You CANNOT LIST AND DESCRIBE THE ACTIONS FOR THAT PLATFORM

--- a/pica_langchain/prompts/default_system.py
+++ b/pica_langchain/prompts/default_system.py
@@ -17,6 +17,9 @@ def get_default_system_prompt(connections_info: str, available_platforms_info: s
 IMPORTANT: ALWAYS START BY LISTING AVAILABLE ACTIONS FOR THE PLATFORM!
 Before attempting any operation, you must first discover what actions are available.
 
+If the user asks about "supported connections" list down the information nicely from available_platforms_info provided in the prompt here
+If the user asks about all the connected platforms, list down the information nicely from connections_info provided in the prompt here
+
 PLATFORM COMMITMENT:
 - You can freely list and explore actions across ANY platform
 - If a platform has no connection:


### PR DESCRIPTION
## Description
This PR adds a new `authkit_supported_platforms` parameter to the [PicaClientOptions](cci:2://file:///Users/alvin/Projects/pica-langchain/pica_langchain/models.py:253:0-283:5) class, allowing developers to filter which platforms are shown in the available platforms list to connect with. The scenario is when Pica supported N number of connections, but user platform only want subset of N. 

## Features
- Added `authkit_supported_platforms` parameter to [PicaClientOptions](cci:2://file:///Users/alvin/Projects/pica-langchain/pica_langchain/models.py:253:0-283:5)
- Implemented filtering logic in the client initialization
- Updated example code to demonstrate usage

## Usage
The `authkit_supported_platforms` parameter accepts a list of platform identifiers (the string before the parentheses in the platform display name). For example:

```python
options = PicaClientOptions(
    authkit=True,
    authkit_supported_platforms=["gmail", "google-calendar"],
    connectors=["*"]
)