### PR TITLE
chore: enforce the LLM to extract the platform connection definition list

### DIFF
--- a/pica_langchain/prompts/authkit_system.py
+++ b/pica_langchain/prompts/authkit_system.py
@@ -149,5 +149,11 @@ IMPORTANT GUIDELINES:
 
 - Here are the proper platform names (according to Pica) to use for tools:
 {available_platforms_info}
+
+CRITICAL: When referring to platforms in your tools and responses, you MUST use ONLY the exact platform identifier (the text before the parentheses) from the list above. For example:
+- For "gmail (Gmail)" use "gmail" as the platform identifier
+- For "google-calendar (Google Calendar)" use "google-calendar" as the platform identifier
+- For "slack (Slack)" use "slack" as the platform identifier
+DO NOT use the display name in parentheses. Always use the exact identifier before the parentheses.
 """
     return prompt 


### PR DESCRIPTION
## Description
This PR enhances the system prompt to make platform name extraction more deterministic when using the PromptToConnectPlatformTool.

## Problem
LLM sometimes generates inconsistent platform names:
- Using the display name (e.g., "Gmail" instead of "gmail")
- Using the entire format (e.g., "gmail (Gmail)")
- Using just the title (e.g., "Google Calendar" instead of "google-calendar")

This causes issues when the platform name is passed to the available-connectors API.

## Solution
Added clear instructions for the LLM to:
- Use ONLY the exact platform identifier (text before parentheses)
- Never use the display name in parentheses
- Follow specific examples for common platforms

This ensures consistent platform names for the PicaOS API.